### PR TITLE
Subgraph: Organization active

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -6,6 +6,7 @@ type Organization @entity {
   wrappableToken: Token
   proposalCount: Int!
   proposals: [Proposal!] @derivedFrom(field: "organization")
+  active: Boolean!
 }
 
 type Config @entity {

--- a/packages/subgraph/src/helpers/index.ts
+++ b/packages/subgraph/src/helpers/index.ts
@@ -55,6 +55,7 @@ export function loadOrCreateOrg(orgAddress: Address): OrganizationEntity | null 
     organization = new OrganizationEntity(id)
     organization.config = config.id
     organization.proposalCount = 0
+    organization.active = false
 
     config.save()
   }

--- a/packages/subgraph/src/mappings/GardensTemplate.ts
+++ b/packages/subgraph/src/mappings/GardensTemplate.ts
@@ -8,14 +8,19 @@ import { Kernel as KernelTemplate } from '../../generated/templates'
 import { loadOrCreateOrg } from '../helpers'
 
 export function handleDeployDao(event: DeployDaoEvent): void {
-  let org = loadOrCreateOrg(event.params.dao)
+  const org = loadOrCreateOrg(event.params.dao)
   org.createdAt = event.block.timestamp
   org.save()
 
   KernelTemplate.create(event.params.dao)
 }
 
-export function handleSetupDao(event: SetupDaoEvent): void {}
+export function handleSetupDao(event: SetupDaoEvent): void {
+  const org = loadOrCreateOrg(event.params.dao)
+  // Set org as active when dao setup finished
+  org.active = true
+  org.save()
+}
 
 export function handleDeployToken(event: DeployTokenEvent): void {}
 

--- a/packages/subgraph/src/processors.ts
+++ b/packages/subgraph/src/processors.ts
@@ -33,5 +33,6 @@ export function processApp(orgAddress: Address, appAddress: Address, appId: stri
 export function processOrg(orgAddress: Address, timestamp: BigInt): void {
   const org = loadOrCreateOrg(orgAddress)
   org.createdAt = timestamp
+  org.active = true
   org.save()
 }


### PR DESCRIPTION
Adds `active` attr to `Organization` entity.
This is so we can filter by orgs that successfully completed the dao setup. 

Note that for tracked orgs created outside `GardensTemplate` we set them as active on dao creation.