### PR TITLE
Subgraph: Handle wrappable token creation on coviction voting

### DIFF
--- a/packages/subgraph/manifest/templates/contracts/ConvictionVoting.template.yaml
+++ b/packages/subgraph/manifest/templates/contracts/ConvictionVoting.template.yaml
@@ -8,6 +8,9 @@
     apiVersion: 0.0.1
     language: wasm/assemblyscript
     entities:
+      - Organization
+      - Token
+      - Config
       - ConvictionConfig
       - Proposal
       - Stake
@@ -17,6 +20,8 @@
         file: ./abis/Agreement.json
       - name: ConvictionVoting
         file: ./abis/ConvictionVoting.json
+      - name: HookedTokenManager
+        file: ./abis/HookedTokenManager.json
       - name: MiniMeToken
         file: ./abis/MiniMeToken.json
     eventHandlers:

--- a/packages/subgraph/manifest/templates/contracts/Organization.template.yaml
+++ b/packages/subgraph/manifest/templates/contracts/Organization.template.yaml
@@ -26,8 +26,6 @@
         file: ./abis/ConvictionVoting.json
       - name: DisputableVoting
         file: ./abis/DisputableVoting.json
-      - name: HookedTokenManager
-        file: ./abis/HookedTokenManager.json
       - name: Kernel
         file: ./abis/Kernel.json  
       - name: MiniMeToken

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -12,6 +12,7 @@ type Config @entity {
   id: ID!
   conviction: ConvictionConfig
   voting: VotingConfig
+  tokens: Bytes
 }
 
 type ConvictionConfig @entity {

--- a/packages/subgraph/src/helpers/conviction.ts
+++ b/packages/subgraph/src/helpers/conviction.ts
@@ -10,6 +10,7 @@ import {
   ProposalAdded as ProposalAddedEvent,
 } from '../../generated/templates/ConvictionVoting/ConvictionVoting'
 import { loadOrCreateConfig, loadTokenData } from '.'
+import { loadWrappableToken } from './tokens'
 
 /// /// Conviction config entity //////
 function getConvictionConfigEntityId(appAddress: Address): string {
@@ -53,6 +54,11 @@ export function loadConvictionConfig(orgAddress: Address, appAddress: Address): 
   if (requestTokenId) {
     convictionConfig.requestToken = requestToken.toHexString()
   }
+
+  // Load wrappable token data
+  // Note we handle the wrappable token here to make sure the
+  // initialize event was already called for the tokens app
+  loadWrappableToken(orgAddress)
 
   // Load conviction params
   convictionConfig.decay = convictionVoting.decay()

--- a/packages/subgraph/src/helpers/tokens.ts
+++ b/packages/subgraph/src/helpers/tokens.ts
@@ -1,0 +1,20 @@
+import { Address } from '@graphprotocol/graph-ts'
+import { ConvictionVoting as ConvictionVotingContract } from '../../generated/templates/ConvictionVoting/ConvictionVoting'
+import { HookedTokenManager as HookedTokenManagerContract } from '../../generated/templates/ConvictionVoting/HookedTokenManager'
+import { loadOrCreateConfig, loadOrCreateOrg, loadTokenData } from '.'
+
+export function loadWrappableToken(convictionVotingAddress: Address): void {
+  const convictionVotingApp = ConvictionVotingContract.bind(convictionVotingAddress)
+  const orgAddress = convictionVotingApp.kernel()
+  const orgConfig = loadOrCreateConfig(orgAddress)
+
+  const tokensApp = HookedTokenManagerContract.bind(orgConfig.tokens as Address)
+  const wrappableTokenAddress = tokensApp.wrappableToken()
+
+  const tokenId = loadTokenData(wrappableTokenAddress)
+  if (tokenId) {
+    const org = loadOrCreateOrg(orgAddress)
+    org.wrappableToken = wrappableTokenAddress.toHexString()
+    org.save()
+  }
+}

--- a/packages/subgraph/src/helpers/tokens.ts
+++ b/packages/subgraph/src/helpers/tokens.ts
@@ -1,13 +1,9 @@
 import { Address } from '@graphprotocol/graph-ts'
-import { ConvictionVoting as ConvictionVotingContract } from '../../generated/templates/ConvictionVoting/ConvictionVoting'
 import { HookedTokenManager as HookedTokenManagerContract } from '../../generated/templates/ConvictionVoting/HookedTokenManager'
 import { loadOrCreateConfig, loadOrCreateOrg, loadTokenData } from '.'
 
-export function loadWrappableToken(convictionVotingAddress: Address): void {
-  const convictionVotingApp = ConvictionVotingContract.bind(convictionVotingAddress)
-  const orgAddress = convictionVotingApp.kernel()
+export function loadWrappableToken(orgAddress: Address): void {
   const orgConfig = loadOrCreateConfig(orgAddress)
-
   const tokensApp = HookedTokenManagerContract.bind(orgConfig.tokens as Address)
   const wrappableTokenAddress = tokensApp.wrappableToken()
 

--- a/packages/subgraph/src/mappings/ConvictionVoting.ts
+++ b/packages/subgraph/src/mappings/ConvictionVoting.ts
@@ -44,6 +44,7 @@ import {
   STAKE_TYPE_ADD,
   STAKE_TYPE_WITHDRAW,
 } from '../types'
+import { loadWrappableToken } from '../helpers/tokens'
 
 export function handleConfigChanged(event: ConvictionSettingsChangedEvent): void {
   const convictionConfig = getConvictionConfigEntity(event.address)
@@ -53,6 +54,10 @@ export function handleConfigChanged(event: ConvictionSettingsChangedEvent): void
   convictionConfig.minThresholdStakePercentage = event.params.minThresholdStakePercentage
 
   convictionConfig.save()
+
+  // Note: we handle the wrappable token here to make sure the
+  // initialize event was already called for the tokens app
+  loadWrappableToken(event.address)
 }
 
 export function handleProposalAdded(event: ProposalAddedEvent): void {

--- a/packages/subgraph/src/mappings/ConvictionVoting.ts
+++ b/packages/subgraph/src/mappings/ConvictionVoting.ts
@@ -44,7 +44,6 @@ import {
   STAKE_TYPE_ADD,
   STAKE_TYPE_WITHDRAW,
 } from '../types'
-import { loadWrappableToken } from '../helpers/tokens'
 
 export function handleConfigChanged(event: ConvictionSettingsChangedEvent): void {
   const convictionConfig = getConvictionConfigEntity(event.address)
@@ -54,10 +53,6 @@ export function handleConfigChanged(event: ConvictionSettingsChangedEvent): void
   convictionConfig.minThresholdStakePercentage = event.params.minThresholdStakePercentage
 
   convictionConfig.save()
-
-  // Note: we handle the wrappable token here to make sure the
-  // initialize event was already called for the tokens app
-  loadWrappableToken(event.address)
 }
 
 export function handleProposalAdded(event: ProposalAddedEvent): void {

--- a/packages/subgraph/src/processors.ts
+++ b/packages/subgraph/src/processors.ts
@@ -1,6 +1,5 @@
-import { Address, BigInt, DataSourceTemplate } from '@graphprotocol/graph-ts'
-import { HookedTokenManager as HookedTokenManagerContract } from '../generated/Kernel/HookedTokenManager'
-import { loadOrCreateOrg, loadTokenData } from './helpers'
+import { Address, BigInt, Bytes, DataSourceTemplate } from '@graphprotocol/graph-ts'
+import { loadOrCreateConfig, loadOrCreateOrg } from './helpers'
 import { onAppTemplateCreated } from './hooks'
 import { AGREEMENT_APPIDS, CONVICTION_VOTING_APPIDS, TOKENS_APPIDS, VOTING_APPIDS } from './appIds'
 
@@ -14,14 +13,9 @@ export function processApp(orgAddress: Address, appAddress: Address, appId: stri
   } else if (AGREEMENT_APPIDS.includes(appId)) {
     template = 'Agreement'
   } else if (TOKENS_APPIDS.includes(appId)) {
-    const tokensApp = HookedTokenManagerContract.bind(appAddress)
-    const wrappableTokenAddress = tokensApp.wrappableToken()
-    const tokenId = loadTokenData(wrappableTokenAddress)
-    if (tokenId) {
-      const org = loadOrCreateOrg(orgAddress)
-      org.wrappableToken = wrappableTokenAddress.toHexString()
-      org.save()
-    }
+    const orgConfig = loadOrCreateConfig(orgAddress)
+    orgConfig.tokens = appAddress
+    orgConfig.save()
   }
 
   if (template) {

--- a/packages/subgraph/src/processors.ts
+++ b/packages/subgraph/src/processors.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes, DataSourceTemplate } from '@graphprotocol/graph-ts'
+import { Address, BigInt, DataSourceTemplate } from '@graphprotocol/graph-ts'
 import { loadOrCreateConfig, loadOrCreateOrg } from './helpers'
 import { onAppTemplateCreated } from './hooks'
 import { AGREEMENT_APPIDS, CONVICTION_VOTING_APPIDS, TOKENS_APPIDS, VOTING_APPIDS } from './appIds'


### PR DESCRIPTION
We noted that we need to handle the wrappable token creation after the initialize event was called. We decided to handle it for now on the Conviction Voting `handleSettingChange` event that will be processed on the second transaction during the Gardens creation on the template.