### PR TITLE
Organzation: Set stake token as org's token

### DIFF
--- a/packages/subgraph/src/helpers/conviction.ts
+++ b/packages/subgraph/src/helpers/conviction.ts
@@ -9,7 +9,7 @@ import {
   ConvictionVoting as ConvictionVotingContract,
   ProposalAdded as ProposalAddedEvent,
 } from '../../generated/templates/ConvictionVoting/ConvictionVoting'
-import { loadOrCreateConfig, loadTokenData } from '.'
+import { loadOrCreateConfig, loadOrCreateOrg, loadTokenData } from '.'
 import { loadWrappableToken } from './tokens'
 
 /// /// Conviction config entity //////
@@ -42,6 +42,11 @@ export function loadConvictionConfig(orgAddress: Address, appAddress: Address): 
   const stakeTokenId = loadTokenData(stakeToken)
   if (stakeTokenId) {
     convictionConfig.stakeToken = stakeToken.toHexString()
+
+    // Set token for org
+    const org = loadOrCreateOrg(orgAddress)
+    org.token = stakeToken.toHexString()
+    org.save()
   }
   const stableTokenId = loadTokenData(stableToken)
   if (stableTokenId) {

--- a/packages/subgraph/src/mappings/DisputableVoting.ts
+++ b/packages/subgraph/src/mappings/DisputableVoting.ts
@@ -43,7 +43,7 @@ export function handleNewSetting(event: NewSettingEvent): void {
   const currentSettingId = getVotingConfigEntityId(event.address, event.params.settingId)
   const votingConfig = getVotingConfigEntity(event.address, event.params.settingId)
 
-  const daoAddress = votingApp.kernel()
+  const orgAddress = votingApp.kernel()
 
   votingConfig.settingId = event.params.settingId
   votingConfig.voteTime = settingData.value0
@@ -58,15 +58,10 @@ export function handleNewSetting(event: NewSettingEvent): void {
   const tokenId = loadTokenData(token)
   if (tokenId) {
     votingConfig.token = token.toHexString()
-
-    // Set token for org
-    const org = loadOrCreateOrg(daoAddress)
-    org.token = token.toHexString()
-    org.save()
   }
   votingConfig.save()
 
-  const config = loadOrCreateConfig(daoAddress)
+  const config = loadOrCreateConfig(orgAddress)
   config.voting = currentSettingId
   config.save()
 }


### PR DESCRIPTION
Sets the stake token as the org's token since in gardens where the voting aggregator is installed, the voting token would be the `aToken`