### PR TITLE
Subgraph: update deployment data

### DIFF
--- a/packages/subgraph/manifest/data/polygon-staging.json
+++ b/packages/subgraph/manifest/data/polygon-staging.json
@@ -1,0 +1,33 @@
+{
+    "network": "matic",
+    "dataSources": {
+      "Organizations": [],
+      "OrganizationTemplates": [
+        {
+          "address": "0xA0E390917991c3D41332a0485510DcfbF502c5e5",
+          "name": "GardensTemplate",
+          "startBlock": 23934752
+        }
+      ]
+    },
+    "agreementAppIds": [
+      {
+        "id": "0x34c62f3aec3073826f39c2c35e9a1297d9dbf3cc77472283106f09eee9cf47bf", "name": "agreement.open.aragonpm.eth"
+      }
+    ],
+    "convictionVotingAppIds": [
+      {
+        "id": "0xca60629a22f03bcad7738fee1a6f0c5863eb89463621b40566a6799b82cbe184", "name": "disputable-conviction-voting.open.aragonpm.eth"
+      }
+    ],
+    "votingAppIds": [
+      { 
+        "id": "0x705b5084c67966bb8e4640b28bab7a1e51e03d209d84e3a04d2a4f7415f93b34", "name": "disputable-voting.open.aragonpm.eth"
+      }
+    ],
+    "tokensAppIds": [
+      { 
+        "id": "0x3ccad1fc11d5b14e58c1c53a5138a51f4da8d509831bc505e60bb74d88f8bef5", "name": "wrappable-hooked-token-manager.open.aragonpm.eth"
+      }
+    ]
+  }

--- a/packages/subgraph/manifest/data/polygon-staging.json
+++ b/packages/subgraph/manifest/data/polygon-staging.json
@@ -4,12 +4,19 @@
       "Organizations": [],
       "OrganizationTemplates": [
         {
-          "address": "0xA0E390917991c3D41332a0485510DcfbF502c5e5",
+          "address": "0x64A35Cafb5FE1f70F4DF29A9bC550e93a11369F9",
           "name": "GardensTemplate",
-          "startBlock": 23934752
+          "startBlock": 21939075
+        },
+        {
+          "address": "0x9e18a165995a69e45bc4adff7795c6ca032048a7",
+          "name": "GardensTemplateWithModVotingFixedApproved",
+          "startBlock": 23936517
         }
       ]
     },
+    "1HiveGarden": "0x0000000000000000000000000000000000000000",
+    "1HivePriceOracle": "0x0000000000000000000000000000000000000000",
     "agreementAppIds": [
       {
         "id": "0x34c62f3aec3073826f39c2c35e9a1297d9dbf3cc77472283106f09eee9cf47bf", "name": "agreement.open.aragonpm.eth"

--- a/packages/subgraph/manifest/data/polygon.json
+++ b/packages/subgraph/manifest/data/polygon.json
@@ -4,9 +4,9 @@
     "Organizations": [],
     "OrganizationTemplates": [
       {
-        "address": "0x64A35Cafb5FE1f70F4DF29A9bC550e93a11369F9",
+        "address": "0x060539E05eBCaA92af533Ad9Cb2121df23426BF3",
         "name": "GardensTemplate",
-        "startBlock": 21939075
+        "startBlock": 23830600
       }
     ]
   },

--- a/packages/subgraph/manifest/data/polygon.json
+++ b/packages/subgraph/manifest/data/polygon.json
@@ -4,30 +4,41 @@
     "Organizations": [],
     "OrganizationTemplates": [
       {
-        "address": "0x060539E05eBCaA92af533Ad9Cb2121df23426BF3",
+        "address": "0x64A35Cafb5FE1f70F4DF29A9bC550e93a11369F9",
         "name": "GardensTemplate",
-        "startBlock": 23830600
+        "startBlock": 21939075
+      },
+      {
+        "address": "0x355649387E53A66246F1d5D70c1BCdE7E9428B79",
+        "name": "GardensTemplateWithModVotingFixedApproved",
+        "startBlock": 23936766
       }
     ]
   },
+  "1HiveGarden": "0x0000000000000000000000000000000000000000",
+  "1HivePriceOracle": "0x0000000000000000000000000000000000000000",
   "agreementAppIds": [
     {
-      "id": "0x34c62f3aec3073826f39c2c35e9a1297d9dbf3cc77472283106f09eee9cf47bf", "name": "agreement.open.aragonpm.eth"
+      "id": "0x34c62f3aec3073826f39c2c35e9a1297d9dbf3cc77472283106f09eee9cf47bf",
+      "name": "agreement.open.aragonpm.eth"
     }
   ],
   "convictionVotingAppIds": [
     {
-      "id": "0xca60629a22f03bcad7738fee1a6f0c5863eb89463621b40566a6799b82cbe184", "name": "disputable-conviction-voting.open.aragonpm.eth"
+      "id": "0xca60629a22f03bcad7738fee1a6f0c5863eb89463621b40566a6799b82cbe184",
+      "name": "disputable-conviction-voting.open.aragonpm.eth"
     }
   ],
   "votingAppIds": [
-    { 
-      "id": "0x705b5084c67966bb8e4640b28bab7a1e51e03d209d84e3a04d2a4f7415f93b34", "name": "disputable-voting.open.aragonpm.eth"
+    {
+      "id": "0x705b5084c67966bb8e4640b28bab7a1e51e03d209d84e3a04d2a4f7415f93b34",
+      "name": "disputable-voting.open.aragonpm.eth"
     }
   ],
   "tokensAppIds": [
-    { 
-      "id": "0x3ccad1fc11d5b14e58c1c53a5138a51f4da8d509831bc505e60bb74d88f8bef5", "name": "wrappable-hooked-token-manager.open.aragonpm.eth"
+    {
+      "id": "0x3ccad1fc11d5b14e58c1c53a5138a51f4da8d509831bc505e60bb74d88f8bef5",
+      "name": "wrappable-hooked-token-manager.open.aragonpm.eth"
     }
   ]
 }

--- a/packages/subgraph/manifest/data/rinkeby.json
+++ b/packages/subgraph/manifest/data/rinkeby.json
@@ -38,6 +38,11 @@
         "address": "0xF8A030177865356E2Be8fb5F95a19962E6b57E3e",
         "name": "GardensTemplateWithWrappedRole",
         "startBlock": 9668429
+      },
+      {
+        "address": "0x832a29b1d6c1dfca7075c62d222b40c05183aaae",
+        "name": "GardensTemplateWithWrappedRoleFixedApproved",
+        "startBlock": 10007376
       }
     ]
   },

--- a/packages/subgraph/manifest/data/xdai.json
+++ b/packages/subgraph/manifest/data/xdai.json
@@ -18,6 +18,11 @@
         "address": "0x9B770712603d66Faa8F048EEf4C0Afd2FA7F0844",
         "name": "GardensTemplateWithModVoting",
         "startBlock": 19255064
+      },
+      {
+        "address": "0xd1fc61d57d7201c3645ef84d30df6da5ed2e21ee",
+        "name": "GardensTemplateWithModVotingFixedApproved",
+        "startBlock": 20155579
       }
     ]  
   },

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -16,11 +16,13 @@
     "deploy:xdai": "NETWORK=xdai yarn deploy",
     "deploy:xdai:staging": "STAGING=true NETWORK=xdai yarn deploy",
     "deploy:polygon": "NETWORK=polygon yarn deploy",
+    "deploy:polygon:staging": "STAGING=true NETWORK=polygon yarn deploy",
     "manifest": "./scripts/build-manifest.sh",
     "manifest:rinkeby": "NETWORK=rinkeby yarn manifest",
     "manifest:xdai": "NETWORK=xdai yarn manifest",
     "manifest:xdai:staging": "STAGING=true NETWORK=xdai yarn manifest",
     "manifest:polygon": "NETWORK=polygon yarn manifest",
+    "manifest:polygon:staging": "STAGING=true NETWORK=polygon yarn manifest",
     "clean": "node ../../node_modules/rimraf/bin.js build generated subgraph.yaml src/constants.ts",
     "lint": "eslint --ext .ts,.json,.md,.yaml,.graphql",
     "lint:fix": "eslint --ext ts,.json,.md,.yaml,.graphql --fix"

--- a/packages/subgraph/scripts/deploy.sh
+++ b/packages/subgraph/scripts/deploy.sh
@@ -18,7 +18,7 @@ fi
 
 if [ "$STAGING" ]
 then
-  SUBGRAPH_EXT=$NETWORK'-staging'
+  SUBGRAPH_EXT='-'$NETWORK'-staging'
 fi
 
 echo Deploying subgraph 1hive/gardens${SUBGRAPH_EXT}


### PR DESCRIPTION
closes https://github.com/1Hive/gardens/issues/510

We are updating the subgraph to use the new `GardenTemplate` addresses. And we also include a new subgraph for polygon-staging.